### PR TITLE
Delete require call for `column` layout

### DIFF
--- a/layout/grid.lua
+++ b/layout/grid.lua
@@ -1,4 +1,3 @@
-local column = require "helium.layout.column"
 --my copy of the cssssss grids
 local path   = string.sub(..., 1, string.len(...) - string.len(".grid"))
 local layout = require(path..'.layout')


### PR DESCRIPTION
The column layout is unused and it doesn't have a relative require path, so putting helium in a subdirectory & requiring the grid layout just errors out. In short:

*It's just sitting there*

**menacingly**
