### PR TITLE
fix uninitialized variables in container layout

### DIFF
--- a/layout/container.lua
+++ b/layout/container.lua
@@ -1,8 +1,8 @@
-local path   = string.sub(..., 1, string.len(...) - string.len(".container"))
-local layout = require(path..'.layout')
+local path        = string.sub(..., 1, string.len(...) - string.len(".container"))
+local layout      = require(path .. '.layout')
 
 ---@class Container
-local container = {}
+local container   = {}
 container.__index = container
 
 ---Positions an element within a container
@@ -14,7 +14,7 @@ function container.new(halign, valign)
 		halign = halign or 'left',
 		valign = valign or 'top',
 	}, container)
-	
+
 	return layout(self, self.draw)
 end
 
@@ -23,11 +23,11 @@ local function alignLeft(x, wroot, wchild)
 end
 
 local function alignCenter(x, wroot, wchild)
-	return x+(wroot/2-wchild/2)
+	return x + (wroot / 2 - wchild / 2)
 end
 
 local function alignRight(x, wroot, wchild)
-	return x+(wroot-wchild)
+	return x + (wroot - wchild)
 end
 
 
@@ -53,20 +53,19 @@ end
 
 function container:draw(x, y, width, height, children, hpad, vpad, alignX)
 	local w, h = children[1]:getSize()
-	local x, y 
 
-	if self.halign =='stretch' then
+	if self.halign == 'stretch' then
 		w = width
 		x = x
 	else
-		x = alignHandlerX(self.halign, containerX, containerWidth, w)
+		x = alignHandlerX(self.halign, x, width, w)
 	end
 
-	if self.valign =='stretch' then
-		h = h
+	if self.valign == 'stretch' then
+		h = height
 		y = y
 	else
-		y = alignHandlerY(self.valign, containerY, containerHeight, h)
+		y = alignHandlerY(self.valign, y, height, h)
 	end
 
 	children[1]:draw(x, y, w, h)


### PR DESCRIPTION
variables `x` and `y` shadowed the parameters, and `containerX`, `containerY`, `containerWidth` and `containerHeight` were used without being initialized. they could be replaced by the parameters `width` and `height`

also my auto-formatting reformatted the code